### PR TITLE
Use the shared settings

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,6 @@
+// Use this project as it's own plugin
+unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "src" / "main" / "scala"
+
 addSbtPlugin("com.geirsson"       % "sbt-ci-release" % "1.2.6")
 addSbtPlugin("de.heikoseeberger"  % "sbt-header"     % "5.2.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-// Use this project as it's own plugin
+// Use this project as its own plugin
 unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "src" / "main" / "scala"
 
 addSbtPlugin("com.geirsson"       % "sbt-ci-release" % "1.2.6")


### PR DESCRIPTION
[I found this idea](https://engineering.sharethrough.com/blog/2015/09/23/capturing-common-config-with-an-sbt-parent-plugin/) to use the shared settings for the plugin itself.  So, for example, an unused import in the plugin implementation will stop the build.