### PR TITLE
Share header settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,18 +16,9 @@ inThisBuild(Seq(
   )
 ))
 
-lazy val headerSettings = Seq(
-  // These sbt-header settings can't be set in ThisBuild for some reason
-  headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment),
-  headerLicense  := Some(HeaderLicense.Custom(
-    """|Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
-       |For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
-       |""".stripMargin
-  ))
-)
+addSbtPlugin("de.heikoseeberger"  % "sbt-header"     % "5.2.0")
 
 lazy val sbtGsp = (project in file("."))
-  .settings(headerSettings)
   .settings(
     name         := "sbt-gsp",
     scalaVersion := scala12Version,

--- a/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
+++ b/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
@@ -6,7 +6,11 @@ package edu.gemini.gsp.sbtplugin
 import sbt._
 import sbt.Keys._
 
+import de.heikoseeberger.sbtheader.HeaderPlugin
+
 object GspPlugin extends AutoPlugin {
+
+  import HeaderPlugin.autoImport._
 
   object autoImport {
 
@@ -66,18 +70,29 @@ object GspPlugin extends AutoPlugin {
       scalacOptions in (Compile, doc)     --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports", "-Yno-imports")
     )
 
+    lazy val gspHeaderSettings = Seq(
+      headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment),
+      headerLicense  := Some(HeaderLicense.Custom(
+        """|Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+           |For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+           |""".stripMargin
+      ))
+    )
   }
 
   import autoImport._
 
   override def requires: Plugins =
-    empty
+    HeaderPlugin
 
   override def trigger: PluginTrigger =
     allRequirements
 
   override val projectSettings =
-    inConfig(Compile)(gspScalacSettings) ++ inConfig(Test)(gspScalacSettings)
+    inConfig(Compile)(gspScalacSettings) ++
+      inConfig(Compile)(gspHeaderSettings)  ++
+      inConfig(Test)(gspScalacSettings)  ++
+      inConfig(Test)(gspHeaderSettings)
 
 }
 


### PR DESCRIPTION
This moves the header settings to the shared build settings plugin so they don't have to be specified in each project.