### PR TITLE
Shared JS Settings

### DIFF
--- a/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
+++ b/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
@@ -93,6 +93,11 @@ object GspPlugin extends AutoPlugin {
       scalacOptions in (Compile, doc)     --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports", "-Yno-imports")
     )
 
+    lazy val gspScalaJsSettings = Seq(
+      scalacOptions ~= (_.filterNot(Set("-Xcheckinit"))),
+      scalacOptions += "-P:scalajs:sjsDefinedByDefault"
+    )
+
     lazy val gspCommonSettings =
       gspHeaderSettings ++
       gspScalacSettings 


### PR DESCRIPTION
This is at least an initial attempt at #3.  It includes the settings used by `gsp-math` and may be referenced in a build via:

```scala
  .jsSettings(gspScalaJsSettings: _*)
```

instead of explicitly listing them each time

```scala
  .jsSettings(
    scalacOptions ~= (_.filterNot(Set("-Xcheckinit"))),
    scalacOptions += "-P:scalajs:sjsDefinedByDefault"
   )
```