### PR TITLE
add sonatype public resolver

### DIFF
--- a/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
+++ b/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
@@ -15,7 +15,8 @@ object GspPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val gspGlobalSettings = Seq(
-      scalaVersion := "2.12.8"
+      scalaVersion := "2.12.8",
+      resolvers += Resolver.sonatypeRepo("public")
     )
 
     lazy val gspHeaderSettings = Seq(


### PR DESCRIPTION
This adds the sonatype public resolver, which will let our projects see our own published artifacts more quickly (they get pushed to Maven Central eventually but it can take a few hours).

(Ironically this won't let us see sbt-gsp releases more quickly, which makes sense if you think about it.)