### PR TITLE
Cross-build for 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_install:
   - git fetch --tags

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,15 @@
 
-lazy val scala12Version = "2.12.8"
-
 inThisBuild(
   (homepage := Some(url("https://github.com/gemini-hlsw/sbt-gsp"))) +: gspPublishSettings
 )
 
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
+addSbtPlugin("de.heikoseeberger"         % "sbt-header"   % "5.2.0")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.7")
 
 lazy val sbtGsp = (project in file("."))
-  .settings(
-    name         := "sbt-gsp",
-    scalaVersion := scala12Version,
-    sbtPlugin    := true
-  )
+  .enablePlugins(SbtPlugin)
   .enablePlugins(AutomateHeaderPlugin)
+  .settings(
+    name := "sbt-gsp",
+  )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 // Use this project as its own plugin
 unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "src" / "main" / "scala"
 
-addSbtPlugin("com.geirsson"       % "sbt-ci-release" % "1.2.6")
-addSbtPlugin("de.heikoseeberger"  % "sbt-header"     % "5.2.0")
+addSbtPlugin("com.geirsson"              % "sbt-ci-release" % "1.2.6")
+addSbtPlugin("de.heikoseeberger"         % "sbt-header"     % "5.2.0")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"   % "0.1.7")
 

--- a/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
+++ b/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
@@ -7,6 +7,7 @@ import sbt._
 import sbt.Keys._
 
 import de.heikoseeberger.sbtheader.HeaderPlugin
+import _root_.io.github.davidgregory084.TpolecatPlugin
 
 object GspPlugin extends AutoPlugin {
 
@@ -15,7 +16,8 @@ object GspPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val gspGlobalSettings = Seq(
-      scalaVersion := "2.12.8",
+      scalaVersion := "2.12.9",
+      crossScalaVersions := Seq(scalaVersion.value, "2.13.0"),
       resolvers += Resolver.sonatypeRepo("public")
     )
 
@@ -42,77 +44,20 @@ object GspPlugin extends AutoPlugin {
       )
     )
 
-    lazy val gspScalacSettings = Seq(
-      scalacOptions ++= (
-        Seq(
-          "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
-          "-encoding", "utf-8",                // Specify character encoding used by source files.
-          "-explaintypes",                     // Explain type errors in more detail.
-          "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
-          "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
-          "-language:higherKinds",             // Allow higher-kinded types
-          "-language:implicitConversions",     // Allow definition of implicit functions called views
-          "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
-          "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
-          "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
-          "-Xfuture",                          // Turn on future language features.
-          "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-          "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
-          "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
-          "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
-          "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
-          "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
-          "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
-          "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
-          "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-          "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
-          "-Xlint:option-implicit",            // Option.apply used implicit view.
-          "-Xlint:package-object-classes",     // Class or object defined in package object.
-          "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
-          "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
-          "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
-          "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
-          "-Xlint:unsound-match",              // Pattern match may not be typesafe.
-          "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-          // "-Yno-imports",                      // No predef or default imports
-          "-Ypartial-unification",             // Enable partial unification in type constructor inference
-          "-Ywarn-dead-code",                  // Warn when dead code is identified.
-          "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
-          "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
-          "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
-          "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-          "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
-          "-Ywarn-numeric-widen",              // Warn when numerics are widened.
-          "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
-          "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
-          "-Ywarn-unused:locals",              // Warn if a local definition is unused.
-          "-Ywarn-unused:params",              // Warn if a value parameter is unused.
-          // "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
-          "-Ywarn-unused:privates",            // Warn if a private member is unused.
-          "-Ywarn-value-discard",              // Warn when non-Unit expression results are unused.
-          "-Ywarn-macros:before", // via som
-          "-Yrangepos" // for longer squiggles
-        )
-      ),
-      scalacOptions in (Compile, console) --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports", "-Yno-imports"),
-      scalacOptions in (Compile, doc)     --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports", "-Yno-imports")
-    )
-
     lazy val gspScalaJsSettings = Seq(
       scalacOptions ~= (_.filterNot(Set("-Xcheckinit"))),
       scalacOptions += "-P:scalajs:sjsDefinedByDefault"
     )
 
     lazy val gspCommonSettings =
-      gspHeaderSettings ++
-      gspScalacSettings
+      gspHeaderSettings
 
   }
 
   import autoImport._
 
   override def requires: Plugins =
-    HeaderPlugin
+    HeaderPlugin && TpolecatPlugin
 
   override def trigger: PluginTrigger =
     allRequirements


### PR DESCRIPTION
This sets up GSP projects to cross-build for 2.12 and 2.13, at least until the SeqExec is on 2.13 at which point we can remove 2.12.

Because the compiler flags are different between 2.12 and 2.13 I removed the long list and added the `sbt-tpolecat` plugin (which I did not write) which enforces the same set of options with variations to accommodate different compiler versions.