### PR TITLE
disable self-referenced plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,11 @@ addSbtPlugin("de.heikoseeberger"         % "sbt-header"   % "5.2.0")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.7")
 
 lazy val sbtGsp = (project in file("."))
+  .disablePlugins(GspPlugin)
   .enablePlugins(SbtPlugin)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "sbt-gsp",
   )
+  .settings(gspHeaderSettings)
 


### PR DESCRIPTION
Need to disable the plugin we're building otherwise the plugin will try to cross-publish. This was making the auto-publish fail.