### PR TITLE
Update for SBT 1.3.0 and Scala 2.13.0

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,2 @@
+-Dsbt.color=always
+-Dsbt.supershell=true

--- a/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
+++ b/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
@@ -62,8 +62,10 @@ object GspPlugin extends AutoPlugin {
   override def trigger: PluginTrigger =
     allRequirements
 
+  override val globalSettings =
+    gspGlobalSettings
+
   override val projectSettings =
-    inThisBuild(gspGlobalSettings) ++
     inConfig(Compile)(gspCommonSettings) ++
     inConfig(Test   )(gspCommonSettings)
 


### PR DESCRIPTION
+ Move gspGlobalSettings to globalSettings. Rather than having global defaults propagated directly to projects we define them as globals allowing them to be inherited by the build and projects, or overridden at the build level.
+ Added .jvmopts to enable colour and super shell on zsh when building sbt-gsp itself.