### PR TITLE
Include OrganizeImports and scalafix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ src_managed/
 project/boot/
 project/plugins/project/
 project/hydra.sbt
+project/metals.sbt
 
 # Scala-IDE specific
 .scala_dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ inThisBuild(
 
 addSbtPlugin("de.heikoseeberger"         % "sbt-header"   % "5.6.0")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.11")
+addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix" % "0.9.15")
 
 lazy val sbtGsp = (project in file("."))
   .disablePlugins(GspPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,5 @@ unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "sr
 addSbtPlugin("com.geirsson"              % "sbt-ci-release" % "1.5.3")
 addSbtPlugin("de.heikoseeberger"         % "sbt-header"     % "5.6.0")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"   % "0.1.11")
+addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"   % "0.9.15")
 

--- a/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
+++ b/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
@@ -8,16 +8,21 @@ import sbt.Keys._
 
 import de.heikoseeberger.sbtheader.HeaderPlugin
 import _root_.io.github.davidgregory084.TpolecatPlugin
+import scalafix.sbt.ScalafixPlugin
 
 object GspPlugin extends AutoPlugin {
 
   import HeaderPlugin.autoImport._
+  import ScalafixPlugin.autoImport._
 
   object autoImport {
 
     lazy val gspGlobalSettings = Seq(
       scalaVersion := "2.13.1",
-      resolvers += Resolver.sonatypeRepo("public")
+      resolvers += Resolver.sonatypeRepo("public"),
+      semanticdbEnabled := true, // enable SemanticDB
+      semanticdbVersion := scalafixSemanticdb.revision, // use Scalafix compatible version
+      scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.2.1" // Include OrganizeImport scalafix
     )
 
     lazy val gspHeaderSettings = Seq(
@@ -57,7 +62,7 @@ object GspPlugin extends AutoPlugin {
   import autoImport._
 
   override def requires: Plugins =
-    HeaderPlugin && TpolecatPlugin
+    HeaderPlugin && TpolecatPlugin && ScalafixPlugin
 
   override def trigger: PluginTrigger =
     allRequirements


### PR DESCRIPTION
This PR allows us to use `scalafix OrganizeImports` on the projects. I suppose we can add more rules in the future. Note that it doesn't force you to use it but it makes it very easy to do so

Based on https://github.com/gemini-hlsw/gpp-ui/pull/5