### PR TITLE
Add explicit semanticdb version

### DIFF
--- a/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
+++ b/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
@@ -22,7 +22,8 @@ object GspPlugin extends AutoPlugin {
       resolvers += Resolver.sonatypeRepo("public"),
       semanticdbEnabled := true, // enable SemanticDB
       semanticdbVersion := scalafixSemanticdb.revision, // use Scalafix compatible version
-      scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.2.1" // Include OrganizeImport scalafix
+      scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.2.1", // Include OrganizeImport scalafix
+      addCompilerPlugin(scalafixSemanticdb("4.3.10")) // This is needed for scalafix to run with scala 2.13.2
     )
 
     lazy val gspHeaderSettings = Seq(


### PR DESCRIPTION
This works around a bug between the versions of scalafix and scalameta which makes it fail if you use scala 2.13.2