### PR TITLE
Remove compiler option for scala.js 0.6

### DIFF
--- a/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
+++ b/src/main/scala/edu/gemini/gsp/sbtplugin/GspPlugin.scala
@@ -51,8 +51,7 @@ object GspPlugin extends AutoPlugin {
     )
 
     lazy val gspScalaJsSettings = Seq(
-      scalacOptions ~= (_.filterNot(Set("-Xcheckinit"))),
-      scalacOptions += "-P:scalajs:sjsDefinedByDefault"
+      scalacOptions ~= (_.filterNot(Set("-Xcheckinit")))
     )
 
     lazy val gspCommonSettings =


### PR DESCRIPTION
That compiler option causes troubles while working on scala.js 1.0